### PR TITLE
Fixed to work with keras2onnx-made models

### DIFF
--- a/onnx2keras/converter.py
+++ b/onnx2keras/converter.py
@@ -76,7 +76,14 @@ def onnx_to_keras(onnx_model, input_names,
 
     logger.debug('Gathering weights to dictionary.')
     weights = {}
+
     for onnx_w in onnx_weights:
+        # Simpler solution.  Seems to work with all keras2onnx-made models (July 28 2020)
+        # Unsure if it works with others. See below alternate solution
+        onnx_extracted_weights_name = onnx_w.ListFields()[-1][1]
+        weights[onnx_extracted_weights_name] = numpy_helper.to_array(onnx_w)
+        # Previous code, does not work for models from keras2onnx as of July 28 2020, and likely earlier
+        '''
         try:
             if len(onnx_w.ListFields()) < 4:
                 onnx_extracted_weights_name = onnx_w.ListFields()[1][1]
@@ -86,7 +93,24 @@ def onnx_to_keras(onnx_model, input_names,
         except:
             onnx_extracted_weights_name = onnx_w.ListFields()[3][1]
             weights[onnx_extracted_weights_name] = numpy_helper.to_array(onnx_w)
-
+        '''
+        # Alternate (ugly) solution, based on previous code
+        '''
+        try:
+            if len(onnx_w.ListFields()) < 4:
+                onnx_extracted_weights_name = onnx_w.ListFields()[1][1]
+            else:
+                onnx_extracted_weights_name = onnx_w.ListFields()[2][1]
+            weights[onnx_extracted_weights_name] = numpy_helper.to_array(onnx_w)
+        except:
+            # Ugly fix
+            try:
+                onnx_extracted_weights_name = onnx_w.ListFields()[3][1]
+                weights[onnx_extracted_weights_name] = numpy_helper.to_array(onnx_w)
+            except:
+                onnx_extracted_weights_name = onnx_w.ListFields()[-1][1]
+                weights[onnx_extracted_weights_name] = numpy_helper.to_array(onnx_w)
+        '''
         logger.debug('Found weight {0} with shape {1}.'.format(
                      onnx_extracted_weights_name,
                      weights[onnx_extracted_weights_name].shape))


### PR DESCRIPTION
Using an ONNX model made from keras2onnx resulted in the error discussed here: https://github.com/nerox8664/onnx2keras/issues/23

So, I went and fixed the code to work for such models.  I left the old code in comments in case this broke something for ONNX models made via other means.

~~However, now that it's working for me, I am finding slightly different predictions between the Keras model and the model from onnx2keras (Keras compile model-->keras2onnx save-->onnx load-->onnx2keras).  I'm not sure at what point in that conversion link the difference(s) is(are) being introduced.  In my case, the differences are -0.1% +- 2.3%, with the worst difference being 9.3%.~~
I did some additional testing of the ONNX file by using other software to make the predictions, and the onnx2keras model predictions are identical.  So, the differences in outputs are confirmed to not be due to onnx2keras.