### PR TITLE
Fix for PRelu and elementwise operations

### DIFF
--- a/onnx2keras/activation_layers.py
+++ b/onnx2keras/activation_layers.py
@@ -168,10 +168,12 @@ def convert_prelu(node, params, layers, lambda_func, node_name, keras_name):
     W = ensure_numpy_type(layers[node.input[1]])
 
     if params['change_ordering']:
-        prelu = \
-            keras.layers.PReLU(weights=[W], shared_axes=[1, 2], name=keras_name)
-        layers[node_name] = prelu(input_0)
+        shared_axes = [1, 2]
     else:
-        prelu = \
-            keras.layers.PReLU(weights=[W], shared_axes=[2, 3], name=keras_name)
-        layers[node_name] = prelu(input_0)
+        shared_axes = [2, 3]
+
+    # for case when W.shape (n,). When activation is used for single dimension vector.
+    shared_axes = shared_axes if len(W.shape) > 1 else None
+
+    prelu = keras.layers.PReLU(weights=[W], shared_axes=shared_axes, name=keras_name)
+    layers[node_name] = prelu(input_0)

--- a/onnx2keras/elementwise_layers.py
+++ b/onnx2keras/elementwise_layers.py
@@ -107,7 +107,7 @@ def convert_elementwise_mul(node, params, layers, lambda_func, node_name, keras_
     try:
         mul = keras.layers.Multiply(name=keras_name)
         layers[node_name] = mul([input_0, input_1])
-    except IndexError:
+    except (IndexError, ValueError):
         logger.warning('Failed to use keras.layers.Multiply. Fallback to TF lambda.')
 
         # Doesn't work with constants
@@ -149,7 +149,7 @@ def convert_elementwise_sub(node, params, layers, lambda_func, node_name, keras_
     try:
         sub = keras.layers.Subtract(name=keras_name)
         layers[node_name] = sub([input_0, input_1])
-    except IndexError:
+    except (IndexError, ValueError):
         logger.warning('Failed to use keras.layers.Subtract. Fallback to TF lambda.')
 
         # Doesn't work with constants


### PR DESCRIPTION
**1. Problem with elementwise: it not always raise IndexError. For example I got something like this:**
```
tensorflow.python.framework.errors_impl.InvalidArgumentError: dim 1 not in the interval [-1, 0]. for '{{node 756/ExpandDims}} = ExpandDims[T=DT_FLOAT, Tdim=DT_INT32](756_const1/Const, 756/ExpandDims/dim)' with input shapes: [], [] and with computed input tensors: input[1] = <1>.
```
I can't really say why, but I think this is the same problem that you got with **convert_elementwise_add** (there is already an except on IndexError and ValueError, which allows you to use **Lambda** in case of an unknown error).



**2. Problem with PRelu:**
Sometimes PRelu is used on tensor(vector) of few dimensions than the usual 4-dimensional. For example if we use PRelu on vector of shape (12,), there can't be shared_axes=[1,2] or [2,3]. I think it is not a totally general solution, but it can help someone with problem as described here https://github.com/nerox8664/onnx2keras/issues/84 (IndexError: list assignment index out of range)