### PR TITLE
Fix keras layer naming (the char ":" is not a valid char for a name of keras layer)

### DIFF
--- a/onnx2keras/converter.py
+++ b/onnx2keras/converter.py
@@ -137,6 +137,7 @@ def onnx_to_keras(onnx_model, input_names,
                 postfix = node_index if len(node.output) == 1 else "%s_%s" % (node_index, output_index)
                 keras_names.append('LAYER_%s' % postfix)
             else:
+                output = output.replace(":", "_")
                 keras_names.append(output)
 
         if len(node.output) != 1:


### PR DESCRIPTION
This PR is fixing a naming problem that is causing the call of `Keras` layers to fail.

In `TensorFlow.Keras` the char `:` is not supported for `name_scope` hence using it as a name for layer will cause the computation of a layer to fail ( running the computation of a layer is creating a `named scope` with the layer's name )

Converting the unsupported char `:` to the char `_` instead is suggested here to fix that problem

Supported chars for a `named scope` can be seen [here](https://github.com/tensorflow/tensorflow/blob/r1.2/tensorflow/python/framework/ops.py#L2993)