### PR TITLE
Fix change_ordering=True for global average pool

### DIFF
--- a/onnx2keras/pooling_layers.py
+++ b/onnx2keras/pooling_layers.py
@@ -149,9 +149,9 @@ def convert_global_avg_pool(node, params, layers, lambda_func, node_name, keras_
     global_pool = keras.layers.GlobalAveragePooling2D(data_format='channels_first', name=keras_name)
     input_0 = global_pool(input_0)
 
-    def target_layer(x):
+    def target_layer(x, axis=-1):
         from tensorflow import keras
-        return keras.backend.expand_dims(x)
+        return keras.backend.expand_dims(x, axis=axis)
 
     logger.debug('Now expand dimensions twice.')
     lambda_layer1 = keras.layers.Lambda(target_layer, name=keras_name + '_EXPAND1')


### PR DESCRIPTION
Currently change_ordering=True doesn't conver global average pool. With the addition of argument axis to the target function target_func will fall under this condition
https://github.com/nerox8664/onnx2keras/blob/b5d77c0920eeefef86ea309d7776452a85ec454b/onnx2keras/converter.py#L242
And later conversion here. Sorry didn't test on master, but tested on the latest pypi release and structure is a little changed in a new code
https://github.com/nerox8664/onnx2keras/blob/b5d77c0920eeefef86ea309d7776452a85ec454b/onnx2keras/converter.py#L271