### PR TITLE
Add Resize field; Fix Clip and Upscale2D layer

### DIFF
--- a/onnx2keras/layers.py
+++ b/onnx2keras/layers.py
@@ -70,4 +70,5 @@ AVAILABLE_CONVERTERS = {
     'Pad': convert_padding,
     'Flatten': convert_flatten,
     'Upsample': convert_upsample,
+    'Resize': convert_upsample
 }

--- a/onnx2keras/operation_layers.py
+++ b/onnx2keras/operation_layers.py
@@ -28,6 +28,11 @@ def convert_clip(node, params, layers, lambda_func, node_name, keras_name):
 
     input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
 
+    if 'min' not in params or 'max' not in params:
+        node_input_data = [layers[attr] for attr in node.input[1:]]
+        max_attr, min_attr = max(node_input_data), min(node_input_data)
+        params["max"], params["min"] = max_attr, min_attr
+
     if params['min'] == 0:
         logger.debug("Using ReLU({0}) instead of clip".format(params['max']))
         layer = keras.layers.ReLU(max_value=params['max'], name=keras_name)

--- a/onnx2keras/upsampling_layers.py
+++ b/onnx2keras/upsampling_layers.py
@@ -25,7 +25,8 @@ def convert_upsample(node, params, layers, lambda_func, node_name, keras_name):
     else:
         # for opset version - 9+
         # Upsample since opset version 9 uses input[1] as 'scales' instead of attributes.
-        scale = np.uint8(layers[node.input[1]][-2:])
+        #
+        scale = np.uint8(layers[node.input[2]][-2:])
 
     if params['mode'].decode('utf-8') != 'nearest':
         logger.error('Cannot convert non-nearest upsampling.')


### PR DESCRIPTION
- Add `Resize` key to AVAILABLE_CONVERTERS as `convert_upsample` function
- Add additional Clip logic in case if `min` and `max` params are contained in available layers, not in `node.attributes`
- Resize params are extracted from node.input[2], not from node.input[1]. By some reason, it didn't work with node.input[2] as it is empty. Looks like in new versions the position of resize params has changed