### PR TITLE
Update operation_layers.py

### DIFF
--- a/onnx2keras/operation_layers.py
+++ b/onnx2keras/operation_layers.py
@@ -23,7 +23,11 @@ def convert_clip(node, params, layers, lambda_func, node_name, keras_name):
     :return: None
     """
     logger = logging.getLogger('onnx2keras.clip')
-    if len(node.input) != 1:
+
+    if len(node.input) == 3:
+        params["min"] = ensure_numpy_type(layers[node.input[1]]).astype(int)
+        params["max"] = ensure_numpy_type(layers[node.input[2]]).astype(int)
+    elif len(node.input) != 1:
         assert AttributeError('More than 1 input for clip layer.')
 
     input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)


### PR DESCRIPTION

**Pull Request: Small Correction to convert_clip Function**

This pull request addresses a small correction in the `convert_clip` function, as suggested in [comment #1129549436](https://github.com/gmalivenko/onnx2keras/issues/79#issuecomment-1129549436) of [issue #79](https://github.com/gmalivenko/onnx2keras/issues/79).

### Why:

The convert_clip() expects an key min inside the params. But current ONNX, the min and max value are passed as inputs (not as attribute). This was creating error in some case.

### Note to Reviewers:

Your quick review on this small adjustment is appreciated.
